### PR TITLE
Bump version to 2.0.0-SNAPSHOT for XP 8

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            1.x
 
   release:
     runs-on: ubuntu-latest

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,4 +8,4 @@ appDisplayName = Content Viewer App
 vendorName = Enonic AS
 vendorUrl = https://enonic.com
 xpVersion = 8.0.0-B4
-version=1.6.2-SNAPSHOT
+version=2.0.0-SNAPSHOT


### PR DESCRIPTION
## Summary

- Bumps master from `1.6.2-SNAPSHOT` to `2.0.0-SNAPSHOT` to start the next major line for XP 8.
- Adds `releaseBranch:` config to `.github/workflows/enonic-gradle.yml` so both `master` and `1.x` are recognized as release branches by `enonic/release-tools/build-and-publish`.
- A `1.x` maintenance branch was created from tag `v1.6.1` for ongoing XP 7 fixes; a companion PR against `1.x` adds the same workflow change there (required so the action reads `releaseBranch:` from the branch's own workflow file).

## Test plan

- [ ] CI build green on this PR
- [ ] After merge, master CI run on push picks up the new release-branch list

🤖 Generated with [Claude Code](https://claude.com/claude-code)