### PR TITLE
Add release-branch CI config for 1.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            1.x
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Adds `releaseBranch:` config (`master` + `1.x`) to `.github/workflows/enonic-gradle.yml` on the `1.x` maintenance branch.
- Required so push events to `1.x` are classified as release builds by `enonic/release-tools/build-and-publish` — the action reads `releaseBranch:` from the branch's own workflow file. Without this, pushes to `1.x` would not trigger publishing.
- This branch was created from tag `v1.6.1` to maintain the XP 7 line; master continues on `2.0.0-SNAPSHOT` for XP 8 (#411).

## Test plan

- [ ] CI build green on this PR
- [ ] After merge, a version bump on `1.x` should produce `release == 'true'` from the build-and-publish step

🤖 Generated with [Claude Code](https://claude.com/claude-code)