### PR TITLE
Introduce TOML version catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     include xplibs.context
     include xplibs.content
     include xplibs.portal
-    include "com.enonic.lib:lib-thymeleaf:3.0.0-SNAPSHOT"
+    include libs.lib.thymeleaf
 }
 
 repositories {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,5 @@
+[versions]
+thymeleaf = "3.0.0-SNAPSHOT"
+
+[libraries]
+lib-thymeleaf = { module = "com.enonic.lib:lib-thymeleaf", version.ref = "thymeleaf" }


### PR DESCRIPTION
## Summary

Move the single inline-versioned dependency in `build.gradle` (`com.enonic.lib:lib-thymeleaf:3.0.0-SNAPSHOT`) into a new `gradle/libs.versions.toml`. Part of a wider effort to unify on TOML catalogs across the IdeaProjects tree so bulk dep bumps (XP 8 SNAPSHOTs, etc.) can be driven by a single sed.

Pin-for-pin migration — no version bumps.

## Conventions adopted

- Version keys: short, lowercase, hyphen-separated (`thymeleaf`).
- Library keys: hyphen-separated, `lib-` prefixed (`lib-thymeleaf`) — matches the dominant style across `app-corporate-theme`, `app-facebook-pixel`, `app-google-cse`, etc.
- `[versions]` and `[libraries]` sorted alphabetically.
- `xpVersion` stays in `gradle.properties` (the rest of the toolchain expects it there).
- `xplibs.*` accessors are untouched — they come from the XP gradle plugin.

## Catalog content

```toml
[versions]
thymeleaf = "3.0.0-SNAPSHOT"

[libraries]
lib-thymeleaf = { module = "com.enonic.lib:lib-thymeleaf", version.ref = "thymeleaf" }
```

## Verification

- `./gradlew build --refresh-dependencies` → green.
- `./gradlew dependencies --configuration runtimeClasspath` is byte-identical before and after.

## Test plan

- [x] `./gradlew build --refresh-dependencies` passes locally
- [x] Resolved `runtimeClasspath` matches pre-migration tree exactly
- [ ] CI green